### PR TITLE
Cleanup

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -22,7 +22,7 @@ grep MISSING reports/completeness-crawler.txt
 
 echo "Running coverage.py"
 coverage erase
-coverage run --branch -m pytest --run-raxml --run-generax --junit-xml=reports/junit/junit.xml
+coverage run --branch -m pytest --run-raxml --run-generax --run-blast --junit-xml=reports/junit/junit.xml
 
 echo "Generating reports"
 coverage html

--- a/tests/_private/check/test_standard.py
+++ b/tests/_private/check/test_standard.py
@@ -1,6 +1,9 @@
 
 import topiary
-from topiary._private.check.standard import check_bool, check_float, check_int, check_iter
+from topiary._private.check.standard import check_bool
+from topiary._private.check.standard import check_float
+from topiary._private.check.standard import check_int
+from topiary._private.check.standard import check_iter
 from topiary._private.check.standard import column_to_bool
 
 import pytest

--- a/tests/_private/test_interface.py
+++ b/tests/_private/test_interface.py
@@ -7,6 +7,8 @@ from topiary._private.interface import create_new_dir
 from topiary._private.interface import copy_input_file
 from topiary._private.interface import run_cleanly
 from topiary._private.interface import rmtree
+from topiary._private.interface import _follow_log_generator
+from topiary._private.interface import _follow_log_subproc_wrapper
 
 import os
 import sys
@@ -132,14 +134,16 @@ def test_copy_input_file(tmpdir,test_dataframes):
 
 def test__follow_log_subproc_wrapper():
     # Super simple function that would require lots of test infrastructure to
-    # run. Return True so this is not flagged as missing by test_crawler.
-    return True
+    # run. Touch without calling to test crawler does not flag as missing
+    _follow_log_subproc_wrapper
+    return None
 
 def test__follow_log_generator():
     # Function that would require lots of test infrastructure to run. Logging
-    # not critical to results, so skipping for now. Return True so this is not
-    # flagged as missing by test_crawler.
-    return True
+    # not critical to results, so skipping for now. Touch without calling so 
+    # test crawler does not flag as missing
+    _follow_log_generator
+    return None
 
 
 def test_launch(tmpdir,programs):

--- a/tests/_private/test_threads.py
+++ b/tests/_private/test_threads.py
@@ -2,6 +2,7 @@
 import pytest
 
 from topiary._private import threads
+from topiary._private.threads import _thread
 import time, random
 
 import numpy as np
@@ -94,5 +95,7 @@ def test_thread_manager():
 
 
 def test__thread():
-    # tested implicitly in test_thread_manager.
-    return True
+    # tested implicitly in test_thread_manager. touch but do not call so test
+    # crawler does not flag as missing
+    _thread
+    return None

--- a/tests/completeness_crawler.py
+++ b/tests/completeness_crawler.py
@@ -24,12 +24,12 @@ def code_loader(filename,is_test):
     """
 
     if is_test:
-        function_finder = re.compile("def test_.*?\(.*?")
+        function_finder = re.compile("def test_.*?\\(.*?")
     else:
-        function_finder = re.compile("def .*?\(.*?")
+        function_finder = re.compile("def .*?\\(.*?")
 
     class_check = re.compile("class .*?:")
-    in_class_check = re.compile("def .*?\(self")
+    in_class_check = re.compile("def .*?\\(self")
 
     def_lines = []
     current_function = None
@@ -173,7 +173,7 @@ def completeness_crawler(code_dir,test_dir,bin_dir=None):
             if class_name is not None:
 
                 # Record as method
-                if re.search("\(self",f):
+                if re.search("\\(self",f):
                     fcn = f"{class_name}.{fcn}"
 
                 # Otherwise, not a method, we've moved out of the class

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def get_files(base_dir):
     Traverse base_dir and return a dictionary that keys all files and some
     rudimentary *.ext expressions to absolute paths to those files. They keys
     will be things like "some_dir/test0/rocket.txt" mapping to
-    "c:\some_dir\life\base_dir\some_dir\test0\rocket.txt". The idea is to have
+    "c:/some_dir/life/base_dir/some_dir/test0/rocket.txt". The idea is to have
     easy-to-read cross-platform keys within unit tests.
 
     Classes of keys:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def pytest_addoption(parser):
                      action="store_true",
                      default=False,
                      help="Run tests involving raxml")
+    
+    parser.addoption("--run-blast",
+                     action="store_true",
+                     default=False,
+                     help="Run tests involving blast")
 
 def pytest_collection_modifyitems(config, items):
     """
@@ -39,6 +44,13 @@ def pytest_collection_modifyitems(config, items):
         skipper = pytest.mark.skip(reason="Only run when --run-raxml is given")
         for item in items:
             if "run_raxml" in item.keywords:
+                item.add_marker(skipper)
+
+    # Look for --run-blast argument. Skip test if this is not specified.
+    if not config.getoption("--run-blast"):
+        skipper = pytest.mark.skip(reason="Only run when --run-blast is given")
+        for item in items:
+            if "run_blast" in item.keywords:
                 item.add_marker(skipper)
 
     # If this is a windows box, skip any test with run_generax or run_raxml

--- a/tests/generax/test__reconcile_no_bootstrap.py
+++ b/tests/generax/test__reconcile_no_bootstrap.py
@@ -9,7 +9,6 @@ from topiary._private import Supervisor
 import ete3
 
 import os
-import shutil
 
 @pytest.mark.run_generax
 def test_reconcile_no_bootstrap(generax_data,tmpdir):

--- a/tests/io/test_alignments.py
+++ b/tests/io/test_alignments.py
@@ -7,7 +7,8 @@ from topiary.io.alignments import _validate_seq_writer
 import numpy as np
 import pandas as pd
 
-import os, shutil, re
+import os
+import re
 
 
 def test__validate_seq_writer():
@@ -16,7 +17,10 @@ def test__validate_seq_writer():
     I'm using those unit tests because I can validate written output.
     """
 
-    return True
+    _validate_seq_writer
+    assert True
+    return None
+
 
 def test_write_fasta(test_dataframes,tmpdir):
 

--- a/tests/io/test_dataframe.py
+++ b/tests/io/test_dataframe.py
@@ -2,13 +2,10 @@ import pytest
 
 from topiary.io import read_dataframe
 from topiary.io import write_dataframe
-import numpy as np
 import pandas as pd
 
 import warnings
 import os
-import shutil
-import re
 
 def test_read_dataframe(dataframe_good_files,test_dataframes):
     """

--- a/tests/io/test_paralog_patterns.py
+++ b/tests/io/test_paralog_patterns.py
@@ -15,12 +15,12 @@ import copy
 def test__get_alias_regex():
 
     test_strings = {"ABC": "abc",
-                    "ABC1" :"abc[\ \-_\.]*1",
-                    "1ABc" :"1[\ \-_\.]*abc",
+                    "ABC1" :"abc[\\ \\-_\\.]*1",
+                    "1ABc" :"1[\\ \\-_\\.]*abc",
                     " ABC ":"abc",
-                    "AB C" :"ab[\ \-_\.]*c",
-                    "(ABC)":"\(abc\)",
-                    "[AB C]" :"\[ab[\ \-_\.]*c\]"}
+                    "AB C" :"ab[\\ \\-_\\.]*c",
+                    "(ABC)":"\\(abc\\)",
+                    "[AB C]" :"\\[ab[\\ \\-_\\.]*c\\]"}
     spacers = [" ","-","_","."]
     for t in test_strings:
         assert _get_alias_regex(t,spacers) == test_strings[t]
@@ -37,9 +37,9 @@ def test__get_alias_regex():
 
     test_strings = {"A" :"a",
                     "1" :"1",
-                    "1A":"1[\ \-_\.]*a",
-                    "A1":"a[\ \-_\.]*1",
-                    " A1 " :"a[\ \-_\.]*1"}
+                    "1A":"1[\\ \\-_\\.]*a",
+                    "A1":"a[\\ \\-_\\.]*1",
+                    " A1 " :"a[\\ \\-_\\.]*1"}
     spacers = [" ","-","_","."]
     for t in test_strings:
         assert _get_alias_regex(t,spacers) == test_strings[t]

--- a/tests/io/test_seed.py
+++ b/tests/io/test_seed.py
@@ -49,8 +49,8 @@ def test_read_seed(seed_dataframes,user_seed_dataframes):
 
         # Test paralog patterns
         expected_patterns = {
-            "LY96":"esop[\ \-_\.]*1|ly[\ \-_\.]*96|lymphocyte[\ \-_\.]*antigen[\ \-_\.]*96|myeloid[\ \-_\.]*differentiation[\ \-_\.]*protein[\ \-_\.]*2",
-            "LY86":"ly[\ \-_\.]*86|lymphocyte[\ \-_\.]*antigen[\ \-_\.]*86|md[\ \-_\.]*1|mmd[\ \-_\.]*1|rp[\ \-_\.]*105[\ \-_\.]*associated[\ \-_\.]*3"
+            "LY96":"esop[\\ \\-_\\.]*1|ly[\\ \\-_\\.]*96|lymphocyte[\\ \\-_\\.]*antigen[\\ \\-_\\.]*96|myeloid[\\ \\-_\\.]*differentiation[\\ \\-_\\.]*protein[\\ \\-_\\.]*2",
+            "LY86":"ly[\\ \\-_\\.]*86|lymphocyte[\\ \\-_\\.]*antigen[\\ \\-_\\.]*86|md[\\ \\-_\\.]*1|mmd[\\ \\-_\\.]*1|rp[\\ \\-_\\.]*105[\\ \\-_\\.]*associated[\\ \\-_\\.]*3"
         }
         for k in paralog_patterns:
             print(paralog_patterns[k].pattern)

--- a/tests/ncbi/blast/test_local.py
+++ b/tests/ncbi/blast/test_local.py
@@ -4,17 +4,38 @@ from conftest import get_public_param_defaults
 
 import topiary
 from topiary.ncbi.blast.local import local_blast
-from topiary.ncbi.blast.local import _prepare_for_blast as _pfb
-from topiary.ncbi.blast.local import _construct_args as _ca
+from topiary.ncbi.blast.local import _prepare_for_blast
+from topiary.ncbi.blast.local import _construct_args
 from topiary.ncbi.blast.local import _combine_hits
 from topiary.ncbi.blast.local import _local_blast_thread_function
 
-import Bio.Blast.Applications as apps
+# Functions used in testing
+from topiary.ncbi.blast.make import make_blast_db
 
 import numpy as np
 import pandas as pd
 
-import copy, os
+import copy
+import os
+import glob
+
+def _blast_args_to_keys(blast_args):
+    """
+    Take a list of args like ["blastp","-db","stupid",...] and return a 
+    dictionary where every arg is a key in a dictionary pointing to a value.
+    Assumes a single value for each key and ignores anything not starting 
+    with -. Would return {'-db':'stupid'} from above.
+    """
+    
+    out_dict = {}
+    i = 0
+    while i < len(blast_args):
+        if blast_args[i].startswith('-'):
+            out_dict[blast_args[i]] = blast_args[i+1]
+            i += 1
+        i += 1
+
+    return out_dict      
 
 def test__prepare_for_blast(test_dataframes,tmpdir):
 
@@ -24,7 +45,7 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     f.close()
     fake_blast_db = os.path.join(tmpdir,"GRCh38")
 
-    default_kwargs = get_public_param_defaults(local_blast,_pfb)
+    default_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
     default_kwargs["db"] = fake_blast_db
     default_kwargs["test_skip_blast_program_check"] = True
     default_kwargs["kwargs"] = {}
@@ -32,23 +53,29 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     default_kwargs["sequence"] = df.sequence
 
     # Skip the check for a working blast program.
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**default_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**default_kwargs)
 
     # Should be a list of length 1 holding a single dictionary
     assert type(sequence_list) is list
     assert len(sequence_list) == 5
-    assert blast_function is apps.NcbiblastpCommandline
-    assert type(blast_kwargs) is dict
+    assert type(blast_args) is list
     assert return_singleton == False
 
     # Make sure it got the sequences right
     assert np.array_equal(sequence_list,df.sequence)
 
-    # Make sure the rest of the arguments were done properly
-    assert blast_kwargs["max_target_seqs"] == 100
-    assert blast_kwargs["threshold"] == 0.001
-    assert blast_kwargs["gapopen"] == 11
-    assert blast_kwargs["gapextend"] == 1
+    # Make sure the blast command is constructed correctly
+    assert blast_args[0] == "blastp"
+    assert blast_args[1] == "-db"
+    assert os.path.split(blast_args[2])[-1] == "GRCh38"
+    
+    expected = ['-outfmt', '5',
+                '-max_target_seqs','100',
+                '-threshold', '1.00000e-03',
+                '-gapopen', '11',
+                '-gapextend', '1']
+    for i in range(len(expected)):
+        assert blast_args[i+3] == expected[i]
 
     # -------------------------------------------------------------------------
     # test sequence bits
@@ -56,19 +83,19 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
     kwargs = copy.deepcopy(default_kwargs)
 
     kwargs["sequence"] = "test"
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 1
     assert sequence_list[0] == "test"
     assert return_singleton == True
 
     kwargs["sequence"] = ["test"]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 1
     assert sequence_list[0] == "test"
     assert return_singleton == False
 
     kwargs["sequence"] = ["test","this"]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
     assert len(sequence_list) == 2
     assert sequence_list[0] == "test"
     assert sequence_list[1] == "this"
@@ -81,11 +108,11 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
 
         kwargs["sequence"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
         kwargs["sequence"] = [b]
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # test db
@@ -94,64 +121,70 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
 
     kwargs["db"] = "not_really_db"
     with pytest.raises(FileNotFoundError):
-        sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+        sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     bad_db = [1,False,1.0,-1,None,str,"",{}]
     for b in bad_db:
         print("passing bad db:",b)
         kwargs["db"] = b
         with pytest.raises(FileNotFoundError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # blast_program
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_function == apps.NcbiblastpCommandline
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert blast_args[0] == "blastp"
 
     kwargs["blast_program"] = "tblastx"
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_function == apps.NcbitblastxCommandline
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert  blast_args[0] == "tblastx"
 
     bad_pg = ["not_really_program",1,False,1.0,-1,None,str,"",{}]
     for b in bad_pg:
         print("passing bad blast_program:",b)
         kwargs["blast_program"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+
 
     # -------------------------------------------------------------------------
-    # histlist_size
+    # hitlist_size
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["max_target_seqs"] == 100
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
 
-    kwargs["hitlist_size"] = 50
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["max_target_seqs"] == 50
+    assert blast_kwargs["-max_target_seqs"] == "100"
+
+    kwargs["hitlist_size"] = "50"
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-max_target_seqs"] == "50"
 
     bad_int = [0,False,[],-1,None,str,"",{},int]
     for b in bad_int:
         print("passing bad hitlist_size:",b)
         kwargs["hitlist_size"] = b
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+
 
     # -------------------------------------------------------------------------
     # evalue_cutoff
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["threshold"] == 0.001
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    assert blast_kwargs["-threshold"] == "1.00000e-03"
 
     kwargs["e_value_cutoff"] = 0.01
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["threshold"] == 0.01
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-threshold"] == "1.00000e-02" 
 
     bad_float = [-1,[],None,str,"",{},int]
     for b in bad_float:
@@ -159,37 +192,38 @@ def test__prepare_for_blast(test_dataframes,tmpdir):
         kwargs["e_value_cutoff"] = b
         print("passing bad e_value_cutoff:",b)
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # gapcosts
 
     kwargs = copy.deepcopy(default_kwargs)
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["gapopen"] == 11
-    assert blast_kwargs["gapextend"] == 1
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-gapopen"] == "11"
+    assert blast_kwargs["-gapextend"] == "1"
 
     kwargs["gapcosts"] = [10,1]
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["gapopen"] == 10
-    assert blast_kwargs["gapextend"] == 1
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-gapopen"] == "10"
+    assert blast_kwargs["-gapextend"] == "1"
 
     bad_gap = [-1,[],[1,2,3],[-1,1],[1,-1],["test","this"],None,str,"",{},int]
     for b in bad_gap:
         kwargs["gapcosts"] = b
         print("passing bad gapcosts:",b)
         with pytest.raises(ValueError):
-            sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-
+            sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
 
     # -------------------------------------------------------------------------
     # Extra kwargs
     kwargs = copy.deepcopy(default_kwargs)
     kwargs["kwargs"] = {"extra_kwarg":7}
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**kwargs)
-    assert blast_kwargs["extra_kwarg"] == 7
-
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**kwargs)
+    blast_kwargs = _blast_args_to_keys(blast_args)
+    assert blast_kwargs["-extra_kwarg"] == "7"
 
 def test__construct_args(test_dataframes,tmpdir):
 
@@ -200,20 +234,19 @@ def test__construct_args(test_dataframes,tmpdir):
     fake_blast_db = os.path.join(tmpdir,"GRCh38")
 
     # Create some normal looking inputs to feed into _construct_args
-    pfb_kwargs = get_public_param_defaults(local_blast,_pfb)
+    pfb_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
     pfb_kwargs["db"] = fake_blast_db
     pfb_kwargs["test_skip_blast_program_check"] = True
     pfb_kwargs["kwargs"] = {}
     df = test_dataframes["good-df"].copy()
     pfb_kwargs["sequence"] = df.sequence
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**pfb_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**pfb_kwargs)
 
     # Run in configuration where we will have one query per core (5 threads,
     # 5 cores, 5 input sequences, long max_query_length)
-    kwargs_list, num_threads = _ca(sequence_list=sequence_list,
-                                   blast_function=blast_function,
-                                   blast_kwargs=blast_kwargs,
+    kwargs_list, num_threads = _construct_args(sequence_list=sequence_list,
+                                   blast_args=blast_args,
                                    num_threads=5,
                                    keep_blast_xml=False,
                                    block_size=1,
@@ -233,14 +266,16 @@ def test__construct_args(test_dataframes,tmpdir):
         # Make sure counter is working
         assert a["index"][0] == i
         assert a["index"][1] == i + 1
+        
 
-        assert a["blast_function"] == apps.NcbiblastpCommandline
+        blast_kwargs = _blast_args_to_keys(a["blast_args"])
 
         # useful kwargs
-        assert a["blast_kwargs"]["max_target_seqs"] == 100
-        assert a["blast_kwargs"]["threshold"] == 0.001
-        assert a["blast_kwargs"]["gapopen"] == 11
-        assert a["blast_kwargs"]["gapextend"] == 1
+        assert a["blast_args"][0] == "blastp"
+        assert blast_kwargs["-max_target_seqs"] == "100"
+        assert blast_kwargs["-threshold"] == "1.00000e-03"
+        assert blast_kwargs["-gapopen"] == "11"
+        assert blast_kwargs["-gapextend"] == "1"
 
         # Keep tmp
         assert a["keep_blast_xml"] == False
@@ -249,9 +284,8 @@ def test__construct_args(test_dataframes,tmpdir):
     # test sequence bits
 
     sequence_list = ["test"]
-    all_args, num_threads = _ca(sequence_list=sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list=sequence_list,
+                                blast_args=blast_args,
                                 num_threads=5,
                                 keep_blast_xml=False,
                                 block_size=1,
@@ -263,9 +297,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
     # Machine as two core, auto detect cores. Should have two args
     sequence_list = ["test","this"]
-    all_args, num_threads = _ca(sequence_list=sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list=sequence_list,
+                                blast_args=blast_args,
                                 num_threads=5,
                                 keep_blast_xml=False,
                                 block_size=1,
@@ -278,9 +311,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
     # Machine as one core, auto detect cores. Should have one arg
     sequence_list = ["test","this"]
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=20,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -295,15 +327,14 @@ def test__construct_args(test_dataframes,tmpdir):
     # block_size
     # making sure sequence bits are processed correctly when it's included
 
-    sequence_list, blast_function, blast_kwargs, return_singleton = _pfb(**pfb_kwargs)
+    sequence_list, blast_args, return_singleton = _prepare_for_blast(**pfb_kwargs)
 
     bad_int = [0,False,[],-1,None,str,"",{},int]
     for b in bad_int:
         print("passing bad block_size:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=b,
                                         keep_blast_xml=False,
                                         num_threads=-1,
@@ -312,9 +343,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
 
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -325,9 +355,8 @@ def test__construct_args(test_dataframes,tmpdir):
     assert all_args[0]["index"][1] == 5
 
     # Make sure splitting looks reasonable -- each sequence on own
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=1,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -340,9 +369,8 @@ def test__construct_args(test_dataframes,tmpdir):
 
 
     # Make sure splitting looks reasonable -- 2, 2, 1
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=2,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -356,9 +384,8 @@ def test__construct_args(test_dataframes,tmpdir):
         counter += 2
 
     # Make sure splitting looks reasonable -- 3, 2
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=3,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -372,9 +399,8 @@ def test__construct_args(test_dataframes,tmpdir):
         counter += 3
 
     # Make sure splitting looks reasonable -- 1
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=-1,
@@ -385,18 +411,16 @@ def test__construct_args(test_dataframes,tmpdir):
     # -------------------------------------------------------------------------
     # keep_blast_xml
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=False,
                                 num_threads=3,
                                 manual_num_cores=None)
     assert all_args[0]["keep_blast_xml"] is False
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=5,
                                 keep_blast_xml=True,
                                 num_threads=3,
@@ -408,9 +432,8 @@ def test__construct_args(test_dataframes,tmpdir):
     for b in bad_bool:
         print("passing bad keep_blast_xml:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=5,
                                         keep_blast_xml=b,
                                         num_threads=3,
@@ -420,9 +443,8 @@ def test__construct_args(test_dataframes,tmpdir):
     # -------------------------------------------------------------------------
     # num_threads.
 
-    all_args, num_threads = _ca(sequence_list,
-                                blast_function=blast_function,
-                                blast_kwargs=blast_kwargs,
+    all_args, num_threads = _construct_args(sequence_list,
+                                blast_args=blast_args,
                                 block_size=1,
                                 keep_blast_xml=False,
                                 num_threads=3,
@@ -434,9 +456,8 @@ def test__construct_args(test_dataframes,tmpdir):
     for b in bad_int:
         print("passing bad num_threads:",b)
         with pytest.raises(ValueError):
-            all_args, num_threads = _ca(sequence_list,
-                                        blast_function=blast_function,
-                                        blast_kwargs=blast_kwargs,
+            all_args, num_threads = _construct_args(sequence_list,
+                                        blast_args=blast_args,
                                         block_size=5,
                                         keep_blast_xml=False,
                                         num_threads=b,
@@ -464,10 +485,81 @@ def test__combine_hits(local_blast_output):
     assert type(df_list) is list
     assert len(df_list) == 1
 
-def test__local_blast_thread_function():
+@pytest.mark.skipif(os.name == "nt",reason="blast cannot be installed via conda on windows")
+@pytest.mark.run_blast
+def test__local_blast_thread_function(test_dataframes,
+                                      make_blast_db_files,
+                                      tmpdir):
 
-    pass
+    # Move into temporary directory
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
 
-def test_local_blast():
+    # Make a blast database
+    faa = [make_blast_db_files["test1.faa"],make_blast_db_files["test2.faa"]]
+    out = "blastdb"
+    make_blast_db(faa,db_name=out)
 
-    pass
+    pfb_kwargs = get_public_param_defaults(local_blast,_prepare_for_blast)
+    pfb_kwargs["db"] = "blastdb"
+    pfb_kwargs["test_skip_blast_program_check"] = False
+    pfb_kwargs["kwargs"] = {}
+    df = test_dataframes["good-df"].copy()
+    pfb_kwargs["sequence"] = df.sequence
+
+    sequence_list, blast_args, _ = _prepare_for_blast(**pfb_kwargs)
+
+    out_df = _local_blast_thread_function(sequence_list=sequence_list,
+                                          index=[0,len(sequence_list)],
+                                          blast_args=blast_args,
+                                          keep_blast_xml=True)
+
+    # Should be five sequences and should have created an xml file
+    assert len(out_df) == 5
+    xml_files = glob.glob("*blast-out.xml") 
+    assert len(xml_files) == 1
+    for f in xml_files:
+        os.remove(f)
+
+    # Should be two sequences, single xml file
+    out_df = _local_blast_thread_function(sequence_list=sequence_list,
+                                          index=[0,2],
+                                          blast_args=blast_args,
+                                          keep_blast_xml=True)
+    
+    assert len(out_df) == 2
+    xml_files = glob.glob("*blast-out.xml") 
+    assert len(xml_files) == 1
+    for f in xml_files:
+        os.remove(f)
+
+    os.chdir(cwd)
+
+@pytest.mark.skipif(os.name == "nt",reason="blast cannot be installed via conda on windows")
+@pytest.mark.run_blast
+def test_local_blast(test_dataframes,
+                     make_blast_db_files,
+                     tmpdir):
+
+    # This is a fairly minimal test suite because this function simply wraps and
+    # the set of local functions that are tested extensively in the rest of this
+    # test file. 
+
+    # Move into temporary directory
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
+
+    # Make a blast database
+    faa = [make_blast_db_files["test1.faa"],make_blast_db_files["test2.faa"]]
+    out = "blastdb"
+    make_blast_db(faa,db_name=out)
+
+    df = test_dataframes["good-df"].copy()
+    sequence = df.sequence
+
+    query_hits = local_blast(sequence=sequence,
+                             db="blastdb")
+
+    assert len(sequence) == len(query_hits)
+
+    os.chdir(cwd)

--- a/tests/ncbi/blast/test_make.py
+++ b/tests/ncbi/blast/test_make.py
@@ -8,6 +8,7 @@ import os
 import glob
 
 @pytest.mark.skipif(os.name == "nt",reason="makeblastdb cannot be installed via conda on windows")
+@pytest.mark.run_blast
 def test_make_blast_db(make_blast_db_files,tmpdir):
 
     cwd = os.getcwd()

--- a/tests/ncbi/test__parse_ncbi_line.py
+++ b/tests/ncbi/test__parse_ncbi_line.py
@@ -4,14 +4,17 @@ import pytest
 import topiary
 import copy
 
-from topiary.ncbi._parse_ncbi_line import parse_ncbi_line, _grab_line_meta_data
+from topiary.ncbi._parse_ncbi_line import _grab_line_meta_data
+from topiary.ncbi._parse_ncbi_line import parse_ncbi_line
 
 def test__grab_line_meta_data(ncbi_lines):
 
     # This function is implicitly and rigorously tested by test_parse_ncbi_line.
     # I'd have to make separate test data manually, so I'll rely on
-    # test_parse_ncbi_line.
-    return True
+    # test_parse_ncbi_line. Touch function but do not call so this is not 
+    # flagged as missing by test crawler
+    _grab_line_meta_data
+    return None
 
 
 def test_parse_ncbi_line(ncbi_lines):

--- a/tests/util/test_create_nicknames.py
+++ b/tests/util/test_create_nicknames.py
@@ -92,7 +92,7 @@ def test_create_nicknames(test_dataframes):
     # Do again, but do some stuff that requires escape characters and more
     # interesting regular expressions
     test_df = df.copy()
-    test_df.loc[:,"name"] = ["|rocking","rock","\in","the","usa"]
+    test_df.loc[:,"name"] = ["|rocking","rock","\\in","the","usa"]
     paralog_patterns = {"fixed":("|rock","out"),
                         "junk":(re.compile("the|us."))}
     out_df = util.create_nicknames(test_df,output_column="test1",paralog_patterns=paralog_patterns)

--- a/topiary/_private/check/topiary_dataframe.py
+++ b/topiary/_private/check/topiary_dataframe.py
@@ -162,11 +162,14 @@ def check_topiary_dataframe(df):
 
     if keep is not None:
 
-        # Validate this as a boolean column
-        df.loc[:,"keep"] = column_to_bool(df.loc[:,"keep"],"keep")
+        # Validate this as a boolean column, casting if needed
+        column_as_bool = column_to_bool(df.loc[:,"keep"],"keep")
 
         # Force it to really be bool
         df = df.astype({"keep":bool})
+
+        # Assign our converted values
+        df.loc[:,"keep"] = column_as_bool
 
     # -------------------------------------------------------------------------
     # Process uid column

--- a/topiary/_private/wrap.py
+++ b/topiary/_private/wrap.py
@@ -48,7 +48,7 @@ class IterFromFile(argparse.Action):
                         final_values.append(self._value_type(v))
                     except (TypeError,ValueError):
 
-                        err = f"\n\Reading '{option_string} {values[0]}' as a file.\n"
+                        err = f"\nReading '{option_string} {values[0]}' as a file.\n"
                         err += f"Could not parse line '{v}' as '{type_name}'. {option_string} should\n"
                         err += f"either have a single argument that points to a file with one '{type_name}'\n"
                         err += f"on each line or have one or more arguments that can be interpreted as\n"

--- a/topiary/io/paralog_patterns.py
+++ b/topiary/io/paralog_patterns.py
@@ -34,10 +34,10 @@ def _get_alias_regex(some_string,
     expressions to match those patterns. 
 
     Examples (for spacers = [" ","-","_","."]):
-        "LY96" -> "ly[\ \-_\.]*96"
-        "MD-2" -> "md[\ \-_\.]*2"
-        "myeloid factor 2" -> "myeloid[\ \-_\.]*factor[\ \-_\.]*2"
-        "CDR2L" -> "cdr[\ \-_\.]*2[\ \-_\.]*L"
+        "LY96" -> "ly[\\ \\-_\\.]*96"
+        "MD-2" -> "md[\\ \\-_\\.]*2"
+        "myeloid factor 2" -> "myeloid[\\ \\-_\\.]*factor[\\ \\-_\\.]*2"
+        "CDR2L" -> "cdr[\\ \\-_\\.]*2[\\ \\-_\\.]*L"
 
     Parameters
     ----------

--- a/topiary/ncbi/_parse_ncbi_line.py
+++ b/topiary/ncbi/_parse_ncbi_line.py
@@ -152,16 +152,16 @@ def parse_ncbi_line(line,accession=None):
 
     # Start with [[genus] species]
     sm = None
-    species_pattern = re.compile("\[.*?\[.*?].*?]")
+    species_pattern = re.compile("\\[.*?\\[.*?].*?]")
     for sm in species_pattern.finditer(line):
         pass
     if sm:
         species = sm.group(0)[1:-1]
-        species = re.sub("[\[\]]","",species)
+        species = re.sub("[\\[\\]]","",species)
 
     # If we didn't get species yet, look for [something this]
     if species is None:
-        species_pattern = re.compile("\[.*?\]")
+        species_pattern = re.compile("\\[.*?\\]")
         sm = None
         for sm in species_pattern.finditer(line):
             pass

--- a/topiary/ncbi/blast/make.py
+++ b/topiary/ncbi/blast/make.py
@@ -62,7 +62,7 @@ def make_blast_db(input_files,db_name,overwrite=False,makeblastdb_binary="makebl
     try:
         subprocess.run([makeblastdb_binary],capture_output=True)
     except FileNotFoundError:
-        err = f"\makeblastdb_binary binary '{makeblastdb_binary}' not found in path\n\n"
+        err = f"makeblastdb_binary binary '{makeblastdb_binary}' not found in path\n\n"
         raise ValueError(err)
 
     rand_string = "".join([random.choice(string.ascii_letters) for _ in range(10)])

--- a/topiary/ncbi/blast/read.py
+++ b/topiary/ncbi/blast/read.py
@@ -113,58 +113,60 @@ def records_to_df(blast_records):
         pandas dataframe with all blast hits
     """
 
+    column_stereotype = {'accession': str,
+                         'hit_def': str,
+                         'hit_id': str,
+                         'title': str,
+                         'length': int,
+                         'e_value': float,
+                         'bits': float,
+                         'sequence': str,
+                         'subject_start': int,
+                         'subject_end':int,
+                         'query_start':int,
+                         'query_end':int,
+                         'query':str}
+
     out_df = []
     for record in blast_records:
 
-        # Prepare DataFrame fields.
-        data = {'accession': [],
-                'hit_def': [],
-                'hit_id': [],
-                'title': [],
-                'length': [],
-                'e_value': [],
-                'bits': [],
-                'sequence': [],
-                'subject_start': [],
-                'subject_end':[],
-                'query_start':[],
-                'query_end':[],
-                'query':[]}
-
+        # Make dictionary of empty lists to populate with datatypes
+        data = dict([(c,[]) for c in column_stereotype])
+        
         # Get alignments from blast result.
-        for i, s in enumerate(record.alignments):
+        if len(record.alignments) > 0:
 
-            data['accession'].append(s.accession)
-            data['hit_def'].append(s.hit_def)
-            data['hit_id'].append(s.hit_id)
-            data['title'].append(s.title)
-            data['length'].append(s.length)
-            data['e_value'].append(s.hsps[0].expect)
-            data['bits'].append(s.hsps[0].bits)
-            data['sequence'].append(s.hsps[0].sbjct)
-            data['subject_start'].append(s.hsps[0].sbjct_start)
-            data['subject_end'].append(s.hsps[0].sbjct_end)
-            data['query_start'].append(s.hsps[0].query_start)
-            data['query_end'].append(s.hsps[0].query_end)
-            data['query'].append(record.query)
+            for s in record.alignments:
 
-        if len(record.alignments) == 0:
-            data['accession'].append(pd.NA)
-            data['hit_def'].append(pd.NA)
-            data['hit_id'].append(pd.NA)
-            data['title'].append(pd.NA)
-            data['length'].append(pd.NA)
-            data['e_value'].append(pd.NA)
-            data['bits'].append(pd.NA)
-            data['sequence'].append(pd.NA)
-            data['subject_start'].append(pd.NA)
-            data['subject_end'].append(pd.NA)
-            data['query_start'].append(pd.NA)
-            data['query_end'].append(pd.NA)
-            data['query'].append(record.query)
+                data['accession'].append(s.accession)
+                data['hit_def'].append(s.hit_def)
+                data['hit_id'].append(s.hit_id)
+                data['title'].append(s.title)
+                data['length'].append(int(s.length))
+                data['e_value'].append(float(s.hsps[0].expect))
+                data['bits'].append(float(s.hsps[0].bits))
+                data['sequence'].append(s.hsps[0].sbjct)
+                data['subject_start'].append(int(s.hsps[0].sbjct_start))
+                data['subject_end'].append(int(s.hsps[0].sbjct_end))
+                data['query_start'].append(int(s.hsps[0].query_start))
+                data['query_end'].append(int(s.hsps[0].query_end))
+                data['query'].append(record.query)
 
-        # Port to DataFrame.
-        out_df.append(pd.DataFrame(data))
+                this_df = pd.DataFrame(data)
+
+        else:
+
+            # Build an empty dataframe with defined column types
+            this_df = pd.DataFrame(data)
+            this_df = this_df.astype(column_stereotype)
+            dummy_row = [pd.NA,pd.NA,pd.NA,pd.NA,
+                         pd.NA,np.nan,np.nan,pd.NA,
+                         pd.NA,pd.NA,pd.NA,pd.NA,
+                         record.query]
+            this_df.loc[0,:] = dummy_row
+                         
+        # Append newly constructed dataframe
+        out_df.append(this_df)
 
     out_df = pd.concat(out_df,ignore_index=True)
 

--- a/topiary/ncbi/blast/recip.py
+++ b/topiary/ncbi/blast/recip.py
@@ -608,7 +608,7 @@ def recip_blast(df,
        LY96; hits with 'lymphocyte antigen 86' or 'MD-1' will map to LY86. Hits
        that match neither would not be assigned a paralog. String patterns are
        interpreted literally. The pattern :code:`"[A-Z]"` would be escaped to
-       look for :code:`"\[A\-Z\]"`. If you want to use regular expressions in
+       look for :code:`"\\[A\\-Z\\]"`. If you want to use regular expressions in
        your patterns, pass them in as compiled regular expressions. For example,
 
        .. code-block:: python

--- a/topiary/util/create_nicknames.py
+++ b/topiary/util/create_nicknames.py
@@ -83,6 +83,11 @@ def create_nicknames(df,
             err = f"\ndataframe already has output_column '{output_column}'.\n"
             err += "To overwrite set overwrite_output = True\n\n"
             raise ValueError(err)
+        
+        # Drop existing column if we are overwriting in case it has a different
+        # type from the incoming type (str)
+        df = df.drop(columns=[output_column])
+
     except KeyError:
         pass
 


### PR DESCRIPTION
Cleaned up warnings. This included:

+ A couple of pandas DataFrame warnings regarding type casting. I am now more explicit in column type selection for blast data frames. 
+ Regex escape string warnings raised by flake8. 
+ pytest warnings for test functions returning values rather than None. 

I also deleted unused imports and split a few single-line, multi-module imports into multiple lines. 